### PR TITLE
Added support for kernel >= 4.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Realtek RTL8814AU USB WiFi Driver
 
-Driver for the Edimax EW7833UAC (AC1750 802.11ac Dual-Band Wi-Fi USB 3.0 Adapter) and other adapters using the same Realtek chipset.
+Driver for the Edimax EW7833UAC (AC1750 802.11ac Dual-Band Wi-Fi USB 3.0 Adapter), TP-Link Archer T9UH (AC1900 802.11ac Dual-Band Wi-Fi USB 3.0 Adapter) and other adapters using the same Realtek chipset.
 Modified from the original source code for Linux kernels up to 4.8 with DKMS support.
-Should work on modern Linux kernels from 4.9 to 4.14-rc2 (older and newer kernels might work as well, but were not tested, feel free to let me know if it works on others).
+Should work on modern Linux kernels from 4.9 to 4.16.
 
 ## Usage
 I recommend to install driver using DKMS, since it will make sure to recompile driver once you install newer kernel and generally requires less manual work.

--- a/hal/phydm/phydm_types.h
+++ b/hal/phydm/phydm_types.h
@@ -202,7 +202,15 @@ typedef enum _RT_SPINLOCK_TYPE{
 
 	typedef struct rtl8192cd_priv	*prtl8192cd_priv;
 	typedef struct stat_info		STA_INFO_T,*PSTA_INFO_T;
-	typedef struct timer_list		RT_TIMER, *PRT_TIMER;
+	/** ntauth (a.chouak@protonmail.com)
+ 	 *  ++ 
+ 	 */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+	typedef struct timer_adapter_ RT_TIMER, *PRT_TIMER;
+#else
+	typedef struct timer_list RT_TIMER, *PRT_TIMER;
+#endif
+	/** -- */
 	typedef  void *				RT_TIMER_CALL_BACK;
 
 	#define _TRUE				1
@@ -266,7 +274,15 @@ typedef enum _RT_SPINLOCK_TYPE{
 		#define	ODM_ENDIAN_TYPE			ODM_ENDIAN_BIG
 	#endif
 
-	typedef struct timer_list		RT_TIMER, *PRT_TIMER;
+	/** ntauth (a.chouak@protonmail.com)
+ 	 *  ++ 
+ 	 */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+	typedef struct timer_adapter_ RT_TIMER, *PRT_TIMER;
+#else
+	typedef struct timer_list RT_TIMER, *PRT_TIMER;
+#endif
+	/** -- */
 	typedef  void *				RT_TIMER_CALL_BACK;
 	#define	STA_INFO_T			struct sta_info
 	#define	PSTA_INFO_T		struct sta_info *

--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -311,7 +311,15 @@ extern void rtw_init_timer(_timer *ptimer, void *padapter, void *pfunc);
 __inline static unsigned char _cancel_timer_ex(_timer *ptimer)
 {
 #ifdef PLATFORM_LINUX
-	return del_timer_sync(ptimer);
+	/** ntauth (a.chouak@protonmail.com)
+ 	 *  ++ 
+ 	 */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+		return del_timer_sync(&ptimer->t);
+#else
+		return del_timer_sync(ptimer);
+#endif
+	/** -- */
 #endif
 #ifdef PLATFORM_FREEBSD
 	_cancel_timer(ptimer,0);


### PR DESCRIPTION
The driver now supports kernel >= 4.15 by patching some of the timer related structures (4.15 introduced breaking changes). Tested on Archlinux 4.16.9-1 + TP-Link Archer T9UH, confirmed as working.
![screenshot_20180518_235526](https://user-images.githubusercontent.com/13150392/40259582-fa1b5f4a-5af6-11e8-8c9c-91679d4e944c.png)

