### PR TITLE
Added led-control by aircrack-ng

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,6 @@ ifeq ($(CONFIG_WAPI_SUPPORT), y)
 EXTRA_CFLAGS += -DCONFIG_WAPI_SUPPORT
 endif
 
-
 ifeq ($(CONFIG_EFUSE_CONFIG_FILE), y)
 EXTRA_CFLAGS += -DCONFIG_EFUSE_CONFIG_FILE
 
@@ -403,4 +402,3 @@ help:
 	@echo "RTLWIFI=y	use RTLWIFI from linux kernel not complete !!"
 
 endif
-

--- a/hal/led/hal_usb_led.c
+++ b/hal/led/hal_usb_led.c
@@ -2308,6 +2308,22 @@ void BlinkHandler(PLED_USB pLed)
 		return;
 	}
 
+	#ifdef CONFIG_SW_LED
+	// led_enable 1 is normal blinking so don't cause always on/off
+	if (padapter->registrypriv.led_ctrl != 1) {
+		if (padapter->registrypriv.led_ctrl == 0)
+		{
+			// Cause LED to be always off
+			pLed->BlinkingLedState = RTW_LED_OFF;
+		} else {
+			// Cause LED to be always on for led_ctrl 2 or greater
+			pLed->BlinkingLedState = RTW_LED_ON;
+		}
+		// Skip various switch cases where SwLedBlink*() called below
+		pLed->CurrLedState = LED_UNKNOWN;
+	}
+	#endif
+
 	switch(ledpriv->LedStrategy)
 	{
 		case SW_LED_MODE0:
@@ -5176,5 +5192,3 @@ DeInitLed(
 	_cancel_timer_ex(&(pLed->BlinkTimer));
 	ResetLedStatus(pLed);
 }
-
-

--- a/include/drv_types.h
+++ b/include/drv_types.h
@@ -196,6 +196,9 @@ struct registry_priv
 	#ifdef CONFIG_TX_EARLY_MODE
 	u8   early_mode;
 	#endif
+	#ifdef CONFIG_SW_LED
+	u8   led_ctrl;
+	#endif
 	u8	acm_method;
 	  //UAPSD
 	u8	wmm_enable;
@@ -1174,4 +1177,3 @@ void rtw_dev_pno_debug(struct net_device *net);
 
 
 #endif //__DRV_TYPES_H__
-

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -75,6 +75,10 @@ int rtw_check_fw_ps = 1;
 int rtw_early_mode=1;
 #endif
 
+#ifdef CONFIG_SW_LED
+int rtw_led_ctrl = 1; // default to normal blink
+#endif
+
 int rtw_usb_rxagg_mode = 2;//USB_RX_AGG_DMA =1,USB_RX_AGG_USB=2
 module_param(rtw_usb_rxagg_mode, int, 0644);
 
@@ -270,6 +274,12 @@ module_param(rtw_hw_wps_pbc, int, 0644);
 #ifdef CONFIG_TX_EARLY_MODE
 module_param(rtw_early_mode, int, 0644);
 #endif
+
+#ifdef CONFIG_SW_LED
+module_param(rtw_led_ctrl, int, 0644);
+MODULE_PARM_DESC(rtw_led_ctrl,"Led Control: 0=Always off, 1=Normal blink, 2=Always on");
+#endif
+
 #ifdef CONFIG_ADAPTOR_INFO_CACHING_FILE
 char *rtw_adaptor_info_caching_file_path= "/data/misc/wifi/rtw_cache";
 module_param(rtw_adaptor_info_caching_file_path, charp, 0644);
@@ -502,6 +512,11 @@ _func_enter_;
 #ifdef CONFIG_TX_EARLY_MODE
 	registry_par->early_mode = (u8)rtw_early_mode;
 #endif
+
+#ifdef CONFIG_SW_LED
+	registry_par->led_ctrl = (u8)rtw_led_ctrl;
+#endif
+
 	registry_par->lowrate_two_xmit = (u8)rtw_lowrate_two_xmit;
 	registry_par->rf_config = (u8)rtw_rf_config;
 	registry_par->low_power = (u8)rtw_low_power;
@@ -3227,4 +3242,3 @@ int rtw_disable_gpio_interrupt(struct net_device *netdev, int gpio_num)
 EXPORT_SYMBOL(rtw_disable_gpio_interrupt);
 
 #endif //#ifdef CONFIG_GPIO_API
-


### PR DESCRIPTION
I have an ASUS AC68; because of the stupid LED in front of the device, I do need LED-control, luckily the aircrack-ng branch already provides this code. :)

Did you also know TP-Link released a [newer version](https://www.tp-link.com/us/download/Archer-T9UH.html#Driver)? It still contains build issues and it doesn't have any VHT.

Thanks for providing this version, VHT works fine and connection is stable. :+1: 