### PR TITLE
Disable debug driver info by default

### DIFF
--- a/include/autoconf.h
+++ b/include/autoconf.h
@@ -275,12 +275,12 @@
 /*
  * Debug Related Config
  */
-#define DBG	1
+#define DBG	0
 
-#define CONFIG_DEBUG /* DBG_871X, etc... */
+//#define CONFIG_DEBUG /* DBG_871X, etc... */
 //#define CONFIG_DEBUG_RTL871X /* RT_TRACE, RT_PRINT_DATA, _func_enter_, _func_exit_ */
 
-#define DBG_CONFIG_ERROR_DETECT
+//#define DBG_CONFIG_ERROR_DETECT
 //#define DBG_CONFIG_ERROR_DETECT_INT
 //#define DBG_CONFIG_ERROR_RESET
 


### PR DESCRIPTION
It's filling up the `dmesg`/`journal`, think it's better to enable when needed, what are you thoughts? :)