### PR TITLE
Add missing channels, Use BIT for config and add RTW_2GHZ_CH14 to regdom rd

### DIFF
--- a/hal/rtl8814a/rtl8814a_hal_init.c
+++ b/hal/rtl8814a/rtl8814a_hal_init.c
@@ -6393,7 +6393,7 @@ u8 GetHalDefVar8814A(PADAPTER padapter, HAL_DEF_VARIABLE variable, void *pval)
 			break;
 
 		case HAL_DEF_RX_STBC:
-			*(u8*)pval = 1;
+			*(u8*)pval = 4;
 			break;
 
 		case HAL_DEF_EXPLICIT_BEAMFORMER:
@@ -6590,5 +6590,3 @@ void rtl8814_set_hal_ops(struct hal_ops *pHalFunc)
 	pHalFunc->fill_fake_txdesc = &rtl8814a_fill_fake_txdesc;
 	pHalFunc->hal_get_tx_buff_rsvd_page_num = &GetTxBufferRsvdPageNum8814;
 }
-
-

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -147,7 +147,7 @@ static struct ieee80211_rate rtw_rates[] = {
 #define RTW_G_RATES_NUM	12
 
 #define RTW_2G_CHANNELS_NUM 14
-#define RTW_5G_CHANNELS_NUM 37
+#define RTW_5G_CHANNELS_NUM 41
 
 static struct ieee80211_channel rtw_2ghz_channels[] = {
 	CHAN2G(1, 2412, 0),
@@ -172,15 +172,17 @@ static struct ieee80211_channel rtw_5ghz_a_channels[] = {
 	CHAN5G(42, 0),		CHAN5G(44, 0),
 	CHAN5G(46, 0),		CHAN5G(48, 0),
 	CHAN5G(52, 0),		CHAN5G(56, 0),
-	CHAN5G(60, 0),		CHAN5G(64, 0),
+	CHAN5G(58, 0),		CHAN5G(60, 0),
+	CHAN5G(62, 0),		CHAN5G(64, 0),
 	CHAN5G(100, 0),		CHAN5G(104, 0),
 	CHAN5G(108, 0),		CHAN5G(112, 0),
 	CHAN5G(116, 0),		CHAN5G(120, 0),
 	CHAN5G(124, 0),		CHAN5G(128, 0),
 	CHAN5G(132, 0),		CHAN5G(136, 0),
-	CHAN5G(140, 0),		CHAN5G(149, 0),
-	CHAN5G(153, 0),		CHAN5G(157, 0),
-	CHAN5G(161, 0),		CHAN5G(165, 0),
+	CHAN5G(140, 0),		CHAN5G(144, 0),
+	CHAN5G(149, 0),		CHAN5G(153, 0),
+	CHAN5G(157, 0),		CHAN5G(161, 0),
+	CHAN5G(165, 0),		CHAN5G(169, 0),
 	CHAN5G(184, 0),		CHAN5G(188, 0),
 	CHAN5G(192, 0),		CHAN5G(196, 0),
 	CHAN5G(200, 0),		CHAN5G(204, 0),
@@ -6747,4 +6749,3 @@ void rtw_cfg80211_dev_res_unregister(struct dvobj_priv *dvobj)
 }
 
 #endif /* CONFIG_IOCTL_CFG80211 */
-

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -125,10 +125,17 @@ int rtw_ampdu_amsdu = 0;// 0: disabled, 1:enabled, 2:auto . There is an IOT issu
 int rtw_short_gi = 0xf;
 // BIT0: Enable VHT LDPC Rx, BIT1: Enable VHT LDPC Tx, BIT4: Enable HT LDPC Rx, BIT5: Enable HT LDPC Tx
 int rtw_ldpc_cap = 0x33;
-// BIT0: Enable VHT STBC Rx, BIT1: Enable VHT STBC Tx, BIT4: Enable HT STBC Rx, BIT5: Enable HT STBC Tx
+/* BIT0: Enable VHT STBC Rx, BIT1: Enable VHT STBC Tx, BIT4: Enable HT STBC Rx, BIT5: Enable HT STBC Tx */
 int rtw_stbc_cap = 0x33;
-// BIT0: Enable VHT Beamformer, BIT1: Enable VHT Beamformee, BIT4: Enable HT Beamformer, BIT5: Enable HT Beamformee
-int rtw_beamform_cap = 0x2;
+/*
+* BIT0: Enable VHT SU Beamformer
+* BIT1: Enable VHT SU Beamformee
+* BIT2: Enable VHT MU Beamformer, depend on VHT SU Beamformer
+* BIT3: Enable VHT MU Beamformee, depend on VHT SU Beamformee
+* BIT4: Enable HT Beamformer
+* BIT5: Enable HT Beamformee
+*/
+int rtw_beamform_cap = BIT(1) | BIT(3);
 int rtw_bfer_rf_number = 0; /*BeamformerCapRfNum Rf path number, 0 for auto, others for manual*/
 int rtw_bfee_rf_number = 0; /*BeamformeeCapRfNum  Rf path number, 0 for auto, others for manual*/
 

--- a/os_dep/linux/wifi_regd.c
+++ b/os_dep/linux/wifi_regd.c
@@ -70,11 +70,12 @@ static struct country_code_to_enum_rd allCountries[] = {
 	NL80211_RRF_PASSIVE_SCAN | NL80211_RRF_NO_IBSS)
 
 static const struct ieee80211_regdomain rtw_regdom_rd = {
-	.n_reg_rules = 3,
+	.n_reg_rules = 4,
 	.alpha2 = "99",
 	.reg_rules = {
 		      RTW_2GHZ_CH01_11,
 		      RTW_2GHZ_CH12_13,
+			  RTW_2GHZ_CH14,
 		      RTW_5GHZ_5150_5850,
 		      }
 };
@@ -552,4 +553,3 @@ int rtw_regd_init(_adapter * padapter)
 	return 0;
 }
 #endif //CONFIG_IOCTL_CFG80211
-


### PR DESCRIPTION
Hi @nazar-pc,

I was looking at the aircrack-ng code, and it seems they made a couple of changes.
Could you please tell me if the changes made are correct for this driver and should be included? :)
I've test the changes and so far no issues have occurred:

```
$ iw list                                                                     ✔  1027  16:08:53 
Wiphy phy0
        max # scan SSIDs: 9
        max scan IEs length: 2304 bytes
        max # sched scan SSIDs: 0
        max # match sets: 0
        max # scan plans: 1
        max scan plan interval: -1
        max scan plan iterations: 0
        Retry short limit: 7
        Retry long limit: 4
        Coverage class: 0 (up to 0m)
        Supported Ciphers:
                * WEP40 (00-0f-ac:1)
                * WEP104 (00-0f-ac:5)
                * TKIP (00-0f-ac:2)
                * CCMP-128 (00-0f-ac:4)
        Available Antennas: TX 0 RX 0
        Supported interface modes:
                 * IBSS
                 * managed
                 * AP
                 * P2P-client
                 * P2P-GO
        Band 1:
                Capabilities: 0x19e3
                        RX LDPC
                        HT20/HT40
                        Static SM Power Save
                        RX HT20 SGI
                        RX HT40 SGI
                        TX STBC
                        RX STBC 1-stream
                        Max AMSDU length: 7935 bytes
                        DSSS/CCK HT40
                Maximum RX AMPDU length 65535 bytes (exponent: 0x003)
                Minimum RX AMPDU time spacing: 16 usec (0x07)
                HT Max RX data rate: 450 Mbps
                HT TX/RX MCS rate indexes supported: 0-23
                Bitrates (non-HT):
                        * 1.0 Mbps
                        * 2.0 Mbps
                        * 5.5 Mbps
                        * 11.0 Mbps
                        * 6.0 Mbps
                        * 9.0 Mbps
                        * 12.0 Mbps
                        * 18.0 Mbps
                        * 24.0 Mbps
                        * 36.0 Mbps
                        * 48.0 Mbps
                        * 54.0 Mbps
                Frequencies:
                        * 2412 MHz [1] (30.0 dBm)
                        * 2417 MHz [2] (30.0 dBm)
                        * 2422 MHz [3] (30.0 dBm)
                        * 2427 MHz [4] (30.0 dBm)
                        * 2432 MHz [5] (30.0 dBm)
                        * 2437 MHz [6] (30.0 dBm)
                        * 2442 MHz [7] (30.0 dBm)
                        * 2447 MHz [8] (30.0 dBm)
                        * 2452 MHz [9] (30.0 dBm)
                        * 2457 MHz [10] (30.0 dBm)
                        * 2462 MHz [11] (30.0 dBm)
                        * 2467 MHz [12] (30.0 dBm)
                        * 2472 MHz [13] (30.0 dBm)
                        * 2484 MHz [14] (30.0 dBm)
        Band 2:
                Capabilities: 0x19e3
                        RX LDPC
                        HT20/HT40
                        Static SM Power Save
                        RX HT20 SGI
                        RX HT40 SGI
                        TX STBC
                        RX STBC 1-stream
                        Max AMSDU length: 7935 bytes
                        DSSS/CCK HT40
                Maximum RX AMPDU length 65535 bytes (exponent: 0x003)
                Minimum RX AMPDU time spacing: 16 usec (0x07)
                HT Max RX data rate: 450 Mbps
                HT TX/RX MCS rate indexes supported: 0-23
                VHT Capabilities (0x03c050b2):
                        Max MPDU length: 11454
                        Supported Channel Width: neither 160 nor 80+80
                        RX LDPC
                        short GI (80 MHz)
                        TX STBC
                        SU Beamformee
                        +HTC-VHT
                VHT RX MCS set:
                        1 streams: MCS 0-9
                        2 streams: MCS 0-9
                        3 streams: MCS 0-9
                        4 streams: not supported
                        5 streams: not supported
                        6 streams: not supported
                        7 streams: not supported
                        8 streams: not supported
                VHT RX highest supported: 1300 Mbps
                VHT TX MCS set:
                        1 streams: MCS 0-9
                        2 streams: MCS 0-9
                        3 streams: MCS 0-9
                        4 streams: not supported
                        5 streams: not supported
                        6 streams: not supported
                        7 streams: not supported
                        8 streams: not supported
                VHT TX highest supported: 1300 Mbps
                Bitrates (non-HT):
                        * 6.0 Mbps
                        * 9.0 Mbps
                        * 12.0 Mbps
                        * 18.0 Mbps
                        * 24.0 Mbps
                        * 36.0 Mbps
                        * 48.0 Mbps
                        * 54.0 Mbps
                Frequencies:
                        * 5170 MHz [34] (30.0 dBm)
                        * 5180 MHz [36] (30.0 dBm)
                        * 5190 MHz [38] (30.0 dBm)
                        * 5200 MHz [40] (30.0 dBm)
                        * 5210 MHz [42] (30.0 dBm)
                        * 5220 MHz [44] (30.0 dBm)
                        * 5230 MHz [46] (30.0 dBm)
                        * 5240 MHz [48] (30.0 dBm)
                        * 5260 MHz [52] (30.0 dBm)
                        * 5280 MHz [56] (30.0 dBm)
                        * 5290 MHz [58] (30.0 dBm)
                        * 5300 MHz [60] (30.0 dBm)
                        * 5310 MHz [62] (30.0 dBm)
                        * 5320 MHz [64] (30.0 dBm)
                        * 5500 MHz [100] (30.0 dBm)
                        * 5520 MHz [104] (30.0 dBm)
                        * 5540 MHz [108] (30.0 dBm)
                        * 5560 MHz [112] (30.0 dBm)
                        * 5580 MHz [116] (30.0 dBm)
                        * 5600 MHz [120] (30.0 dBm)
                        * 5620 MHz [124] (30.0 dBm)
                        * 5640 MHz [128] (30.0 dBm)
                        * 5660 MHz [132] (30.0 dBm)
                        * 5680 MHz [136] (30.0 dBm)
                        * 5700 MHz [140] (30.0 dBm)
                        * 5720 MHz [144] (30.0 dBm)
                        * 5745 MHz [149] (30.0 dBm)
                        * 5765 MHz [153] (30.0 dBm)
                        * 5785 MHz [157] (30.0 dBm)
                        * 5805 MHz [161] (30.0 dBm)
                        * 5825 MHz [165] (30.0 dBm)
                        * 5845 MHz [169] (30.0 dBm)
                        * 5920 MHz [184] (disabled)
                        * 5940 MHz [188] (disabled)
                        * 5960 MHz [192] (disabled)
                        * 5980 MHz [196] (disabled)
                        * 6000 MHz [200] (disabled)
                        * 6020 MHz [204] (disabled)
                        * 6040 MHz [208] (disabled)
                        * 6060 MHz [212] (disabled)
                        * 6080 MHz [216] (disabled)
        Supported commands:
                 * new_interface
                 * set_interface
                 * new_key
                 * start_ap
                 * new_station
                 * set_bss
                 * join_ibss
                 * set_pmksa
                 * del_pmksa
                 * flush_pmksa
                 * remain_on_channel
                 * frame
                 * set_channel
                 * connect
                 * disconnect
        Supported TX frame types:
                 * IBSS: 0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0
                 * managed: 0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0
                 * AP: 0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0
                 * AP/VLAN: 0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0
                 * P2P-client: 0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0
                 * P2P-GO: 0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0
        Supported RX frame types:
                 * IBSS: 0xd0
                 * managed: 0x40 0xd0
                 * AP: 0x00 0x20 0x40 0xa0 0xb0 0xc0 0xd0
                 * AP/VLAN: 0x00 0x20 0x40 0xa0 0xb0 0xc0 0xd0
                 * P2P-client: 0x40 0xd0
                 * P2P-GO: 0x00 0x20 0x40 0xa0 0xb0 0xc0 0xd0
        WoWLAN support:
                 * wake up on anything (device continues operating normally)
        software interface modes (can always be added):
        interface combinations are not supported
        Device supports scan flush.
```

I'm a bit confused about the value needed for `HAL_DEF_RX_STBC` and `int rtw_stbc_cap`.
The last one has been changed to `int rtw_stbc_cap = 0x13;` - could you tell me how this works?

If it is better to ask on the aircrack-repo, let me know (Y).

Thanks.